### PR TITLE
Sync and deploy forked repository

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -13,8 +13,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           # 使用具有 repo 范围的个人访问令牌 (PAT) 以便推送更改
-          # GITHUB_TOKEN 的默认权限是只读的
-          token: ${{ secrets.PAT_TOKEN }}
+          # 如果没有配置 PAT_TOKEN，则使用默认的 GITHUB_TOKEN
+          token: ${{ secrets.PAT_TOKEN || github.token }}
           # 获取所有分支和标签的全部历史记录
           fetch-depth: 0
 

--- a/SYNC_SETUP_GUIDE.md
+++ b/SYNC_SETUP_GUIDE.md
@@ -1,0 +1,55 @@
+# Fork 仓库同步设置指南
+
+## 问题说明
+
+你的同步工作流失败是因为缺少必要的访问令牌（token）。GitHub Actions 需要特殊权限来推送更改到你的仓库。
+
+## 解决方案
+
+### 方案一：使用个人访问令牌（推荐）
+
+1. **创建 Personal Access Token (PAT)**：
+   - 访问 GitHub Settings → Developer settings → Personal access tokens → Tokens (classic)
+   - 点击 "Generate new token (classic)"
+   - 设置过期时间（建议选择 "No expiration" 或长期有效）
+   - 选择权限范围：
+     - ✅ `repo` (完整仓库访问权限)
+     - ✅ `workflow` (更新 GitHub Actions 工作流)
+
+2. **在你的仓库中添加 Secret**：
+   - 进入你的 fork 仓库
+   - 点击 Settings → Secrets and variables → Actions
+   - 点击 "New repository secret"
+   - Name: `PAT_TOKEN`
+   - Value: 粘贴你刚创建的 token
+   - 点击 "Add secret"
+
+### 方案二：使用默认 GITHUB_TOKEN（已修复）
+
+我已经修改了你的工作流文件，现在它会：
+- 优先使用 `PAT_TOKEN`（如果你配置了的话）
+- 如果没有配置 `PAT_TOKEN`，则使用默认的 `github.token`
+
+但是，使用默认 token 有一些限制：
+- 可能无法触发其他工作流（如部署工作流）
+- 在某些情况下可能权限不足
+
+## 推荐配置
+
+**强烈建议使用方案一（PAT）**，因为：
+1. 权限更完整
+2. 能确保同步后触发部署工作流
+3. 更稳定可靠
+
+## 验证设置
+
+配置完成后：
+1. 进入 Actions 页面
+2. 手动触发 "Sync Fork" 工作流
+3. 检查是否成功运行
+
+## 注意事项
+
+- PAT 是敏感信息，不要泄露给他人
+- 定期更新 PAT（如果设置了过期时间）
+- 确保原仓库地址正确：`https://github.com/weiruchenai1/api-key-tester.git`


### PR DESCRIPTION
Fix sync workflow failure by providing a fallback token and a setup guide.

The original workflow failed with "Input required and not supplied: token" because it exclusively relied on `secrets.PAT_TOKEN` which was not configured. This PR modifies the workflow to use `github.token` as a fallback, allowing the sync to proceed even without a custom PAT, and includes a detailed guide (`SYNC_SETUP_GUIDE.md`) on how to properly configure a Personal Access Token for more robust synchronization and deployment triggers.

---
<a href="https://cursor.com/background-agent?bcId=bc-4250c2c5-e1dd-49d0-adc9-de58a524dd04">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4250c2c5-e1dd-49d0-adc9-de58a524dd04">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

